### PR TITLE
Updated Inventory and Landing pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
         <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no"/>
         <meta name="theme-color" content="#000000"/><link rel="manifest" href="/manifest.json"/>
         
-        <title>React App</title>
+        <title>Chasing Zero</title>
         
         <link href="/static/css/main.43823119.chunk.css" rel="stylesheet">
         <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">

--- a/package-lock.json
+++ b/package-lock.json
@@ -4637,6 +4637,11 @@
         }
       }
     },
+    "date-fns": {
+      "version": "2.0.0-alpha.27",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.0.0-alpha.27.tgz",
+      "integrity": "sha512-cqfVLS+346P/Mpj2RpDrBv0P4p2zZhWWvfY5fuWrXNR/K38HaAGEkeOwb47hIpQP9Jr/TIxjZ2/sNMQwdXuGMg=="
+    },
     "date-now": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
@@ -13997,6 +14002,18 @@
         }
       }
     },
+    "react-datepicker": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-2.5.0.tgz",
+      "integrity": "sha512-X8D+5CqumSUwoq/x5d8O0neYDRmPmwVcyCktVbs5juXV4s73beV6sMf87hM6lxMSanWeB+jpx8waxJcPqsmCIg==",
+      "requires": {
+        "classnames": "^2.2.5",
+        "date-fns": "^2.0.0-alpha.23",
+        "prop-types": "^15.6.0",
+        "react-onclickoutside": "^6.7.1",
+        "react-popper": "^1.0.2"
+      }
+    },
     "react-dev-utils": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-8.0.0.tgz",
@@ -14147,6 +14164,35 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-onclickoutside": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.8.0.tgz",
+      "integrity": "sha512-5Q4Rn7QLEoh7WIe66KFvYIpWJ49GeHoygP1/EtJyZjXKgrWH19Tf0Ty3lWyQzrEEDyLOwUvvmBFSE3dcDdvagA=="
+    },
+    "react-popper": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.3.tgz",
+      "integrity": "sha512-ynMZBPkXONPc5K4P5yFWgZx5JGAUIP3pGGLNs58cfAPgK67olx7fmLp+AdpZ0+GoQ+ieFDa/z4cdV6u7sioH6w==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "create-react-context": "<=0.2.2",
+        "popper.js": "^1.14.4",
+        "prop-types": "^15.6.1",
+        "typed-styles": "^0.0.7",
+        "warning": "^4.0.2"
+      },
+      "dependencies": {
+        "create-react-context": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.2.tgz",
+          "integrity": "sha512-KkpaLARMhsTsgp0d2NA/R94F/eDLbhXERdIq3LvX2biCAXcDvHYoOqHfWCHf1+OLj+HKBotLG3KqaOOf+C1C+A==",
+          "requires": {
+            "fbjs": "^0.8.0",
+            "gud": "^1.0.0"
+          }
+        }
+      }
     },
     "react-router": {
       "version": "5.0.0",
@@ -17058,6 +17104,11 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.18"
       }
+    },
+    "typed-styles": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
+      "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q=="
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "firebase": "^5.10.0",
     "firebaseui": "^3.6.0",
     "react": "^16.8.6",
+    "react-datepicker": "^2.5.0",
     "react-dom": "^16.8.6",
     "react-router-dom": "^5.0.0",
     "react-scripts": "2.1.8",

--- a/public/index.html
+++ b/public/index.html
@@ -22,7 +22,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Chasing Zero</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.js
+++ b/src/App.js
@@ -87,23 +87,40 @@ class App extends Component {
     }
   }
 
+  // An item has been added/removed to the database, so update inventory state to represent the new collection
+  handleInventoryItemsChanged = () => {
+    try {
+      db.collection('inventory').get().then(snapshot => {
+        var data = [];
+        if (snapshot.empty) {
+          console.log('no data');
+          return
+        }
+        snapshot.forEach(doc => {
+          console.log(Object.assign({}, doc.data(), {"doc_id": doc.id}));
+
+          // We want to save the document ID as well, so save it with the rest of the data fields
+          data.push(Object.assign({}, doc.data(), {"doc_id": doc.id}));
+        })
+        this.setState({
+          inventory: data
+        })
+      })
+    } catch (error) {
+      this.setState({
+        error
+      })
+    }
+  }
+
   // This function removes an item from the database.
   handleRemoveItem(targetItemName, targetDocID) {
     // Remove this item from the database
     db.collection('inventory').doc(targetDocID).delete().then(function() {
-      alert("Successfully deleted item " + targetItemName + " from your inventory. Refresh to see changes");
+      console.log("Successfully deleted item " + targetItemName + " from inventory");
     }).catch(function(error) {
       alert("error removing document: " + error);
     })
-
-    // TODO: Remove from the internal inventory as well (or launch refresh of page automatically), so updates 
-    // are visible in the inventory table.
-    // The following code doesn't work, but the idea is to filter out the deleted item.
-    // let oldInventory = this.state.inventory;
-    // this.setState({
-    //   inventory : oldInventory.filter(item => item.name !== targetItemName)
-    // })
-
   }
 
   render() {
@@ -115,7 +132,8 @@ class App extends Component {
 
             recipeState={this.state.recipe}
             inventoryState={this.state}
-            handleRemoveItem={this.handleRemoveItem} />
+            handleRemoveItem={this.handleRemoveItem} 
+            handleInventoryItemsChanged={this.handleInventoryItemsChanged}/>
 
           <Footer />
         </div>

--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ import firebase from './firebase-config';
 import NavBar from './components/NavBar';
 import Footer from './components/Footer';
 import Routes from './components/Routes';
-import green from '@material-ui/core/colors/green';
+import blueGrey from '@material-ui/core/colors/blueGrey';
 import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 
 // I'm not exactly sure how the theme works, but these colors should look OK?
@@ -22,7 +22,7 @@ const theme = createMuiTheme({
       // contrastText: will be calculated to contrast with palette.primary.main
       contrastText: '#FFFFFF'
     },
-    secondary: green,
+    secondary: blueGrey,
   },
 
   status: {

--- a/src/components/AddInventoryItem.js
+++ b/src/components/AddInventoryItem.js
@@ -5,7 +5,39 @@ import Input from '@material-ui/core/Input';
 import InputLabel from '@material-ui/core/InputLabel';
 import { withStyles } from '@material-ui/core';
 import firebase from '../firebase-config';
+import "react-datepicker/dist/react-datepicker.css";
 const db = firebase.firestore();
+
+// Convert a date from String representation into a Date object
+function stringToDate(_date,_format,_delimiter)
+{
+  var formatLowerCase=_format.toLowerCase();
+  var formatItems=formatLowerCase.split(_delimiter);
+  var dateItems=_date.split(_delimiter);
+  var monthIndex=formatItems.indexOf("mm");
+  var dayIndex=formatItems.indexOf("dd");
+  var yearIndex=formatItems.indexOf("yyyy");
+  var month=parseInt(dateItems[monthIndex]);
+  month-=1;
+  var formatedDate = new Date(dateItems[yearIndex],month,dateItems[dayIndex]);
+  return formatedDate;
+}
+
+// Convert a Date object into a String representation -- not actually used, but I'll keep 
+// the utility function for now.
+function dateToString(dateObject) {
+  var m = new String(dateObject.getMonth() + 1);
+  if (m.length === 1) {
+      m = "0" + m;
+  }
+  var d = new String(dateObject.getDate());
+  if (d.length === 1) {
+      d = "0" + d;
+  }
+  var y = new String(dateObject.getYear() + 1900);
+
+  return m + "/" + d + "/" + y;
+}
 
 const styles = theme => ({
   form: {
@@ -30,13 +62,16 @@ class AddInventoryItem extends Component {
 
     // Choose random number for next item ID
     var nextIdNumber = Math.floor(Math.random() * 1500) + 1;
+    var currentDate = new Date();
+    var defaultExpirationDate = new Date();
+    defaultExpirationDate.setDate(defaultExpirationDate.getDate() + 7);
 
     // Set initial state
     this.state = {
       name: '',
-      boughtOn: '',
-      expiresOn: '',
       id: nextIdNumber,
+      boughtOn: dateToString(currentDate),
+      expiresOn: dateToString(defaultExpirationDate),
     };
 
     this.handleChange = this.handleChange.bind(this);
@@ -63,14 +98,19 @@ class AddInventoryItem extends Component {
 
     db.collection('inventory').add(data);
 
-     // Choose random number for the next item ID
-     var nextIdNumber = Math.floor(Math.random() * 1500) + 1;
+    // Choose random number for the next item ID
+    var nextIdNumber = Math.floor(Math.random() * 1500) + 1;
 
-    // Clear out the form
+    // Reset the boughtOn and expiresOn value
+    var currentDate = new Date();
+    var defaultExpirationDate = new Date();
+    defaultExpirationDate.setDate(defaultExpirationDate.getDate() + 7);
+
+    // Reset the rest of the form
     this.setState({
       name: "",
-      boughtOn: "",
-      expiresOn: "",
+      boughtOn: dateToString(currentDate),
+      expiresOn: dateToString(defaultExpirationDate),
       id: nextIdNumber,
     });
     
@@ -83,44 +123,49 @@ class AddInventoryItem extends Component {
     const {classes} = this.props;
 
     return (
-      <form className={classes.form} onSubmit={this.handleSubmit} required gutterBottom>
-        <FormControl margin="normal" required className={classes.itemspacing}>
-          <InputLabel>Name of Food Item</InputLabel>
-          <Input 
-            id="name" 
-            name="name" 
-            type="text"
-            value={this.state.name}
-            onChange={this.handleChange} />
-        </FormControl>
-        <FormControl margin="normal" required className={classes.itemspacing}>
-          <InputLabel>Bought (MM/DD/YY)</InputLabel>
-          <Input 
-            id="boughtOn" 
-            name="boughtOn"
-            type="text"
-            value={this.state.boughtOn}
-            onChange={this.handleChange}/>
-        </FormControl>
-        <FormControl margin="normal" required className={classes.itemspacing}>
-          <InputLabel>Expires (MM/DD/YY)</InputLabel>
-          <Input 
-            id="expiresOn" 
-            name="expiresOn"
-            type="text"
-            value={this.state.expiresOn}
-            onChange={this.handleChange}/>
-        </FormControl>
+      <div>
+        <p style={{marginLeft: "16px"}}>
+          By default, the item is considered to be 'bought' on the current date, and will expire 1 week from today.
+        </p>
+        <form className={classes.form} onSubmit={this.handleSubmit} required gutterBottom>
+          <FormControl margin="normal" required className={classes.itemspacing}>
+            <InputLabel>Name of Food Item</InputLabel>
+            <Input 
+              id="name" 
+              name="name" 
+              type="text"
+              value={this.state.name}
+              onChange={this.handleChange} />
+          </FormControl>
+          <FormControl margin="normal" required className={classes.itemspacing}>
+            <InputLabel>Bought (MM/DD/YY)</InputLabel>
+            <Input 
+              id="boughtOn" 
+              name="boughtOn"
+              type="text"
+              value={this.state.boughtOn}
+              onChange={this.handleChange}/>
+          </FormControl>
+          <FormControl margin="normal" required className={classes.itemspacing}>
+            <InputLabel>Expires (MM/DD/YY)</InputLabel>
+            <Input 
+              id="expiresOn" 
+              name="expiresOn"
+              type="text"
+              value={this.state.expiresOn}
+              onChange={this.handleChange}/>
+          </FormControl>
 
-        <Button 
-          className={classes.submit}
-          type="submit"
-          variant="contained"
-          color="default"
-        >
-          Add to inventory
-        </Button>
-      </form>
+          <Button 
+            className={classes.submit}
+            type="submit"
+            variant="contained"
+            color="default"
+          >
+            Add to inventory
+          </Button>
+        </form>
+      </div>
     );
   }
 }

--- a/src/components/AddInventoryItem.js
+++ b/src/components/AddInventoryItem.js
@@ -27,12 +27,16 @@ class AddInventoryItem extends Component {
   // Set some default values - the state will get updated as we edit the form
   constructor(props) {
     super(props);
+
+    // Choose random number for next item ID
+    var nextIdNumber = Math.floor(Math.random() * 1500) + 1;
+
+    // Set initial state
     this.state = {
       name: '',
       boughtOn: '',
       expiresOn: '',
-      // TODO: Figure out how to get the next ID number (hard-coded for now)
-      id: 10
+      id: nextIdNumber,
     };
 
     this.handleChange = this.handleChange.bind(this);
@@ -47,6 +51,8 @@ class AddInventoryItem extends Component {
 
   // When we submit the form, add the item to the inventory
   handleSubmit(event) {
+    const { handleInventoryItemsChanged } = this.props;
+
     event.preventDefault();
     var data = {
       name: this.state.name,
@@ -56,7 +62,20 @@ class AddInventoryItem extends Component {
     }
 
     db.collection('inventory').add(data);
-    alert(this.state.name + " was added to your inventory. Refresh to see results");
+
+     // Choose random number for the next item ID
+     var nextIdNumber = Math.floor(Math.random() * 1500) + 1;
+
+    // Clear out the form
+    this.setState({
+      name: "",
+      boughtOn: "",
+      expiresOn: "",
+      id: nextIdNumber,
+    });
+    
+    // Update main app that inventory items were changed => will refresh inventory state to be re-rendered
+    handleInventoryItemsChanged();
   }
 
   // This method generates the form to add items to a user's inventory

--- a/src/components/EmailFormDialog.js
+++ b/src/components/EmailFormDialog.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import Button from '@material-ui/core/Button';
+import TextField from '@material-ui/core/TextField';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogTitle from '@material-ui/core/DialogTitle';
+
+export default class EmailFormDialog extends React.Component {
+  state = {
+    open: false,
+  };
+
+  handleClickOpen = () => {
+    this.setState({ open: true });
+  };
+
+  handleClose = () => {
+    this.setState({ open: false });
+  };
+
+  render() {
+    return (
+      <div>
+        <Button variant="contained" color="secondary" onClick={this.handleClickOpen}>
+            Sign Up for Email Notifications
+        </Button>
+        <Dialog
+          open={this.state.open}
+          onClose={this.handleClose}
+          aria-labelledby="form-dialog-title"
+        >
+          <DialogTitle id="form-dialog-title">Subscribe</DialogTitle>
+          <DialogContent>
+            <DialogContentText>
+              To receive e-mail notifications of expiring foods, please enter your email address here. We will send
+              updates once a day, and you can unsubscribe at any time.
+            </DialogContentText>
+            <TextField
+              autoFocus
+              margin="dense"
+              id="name"
+              label="Email Address"
+              type="email"
+              fullWidth
+            />
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={this.handleClose} color="primary">
+              Cancel
+            </Button>
+            <Button onClick={this.handleClose} color="primary">
+              Sign Up
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </div>
+    );
+  }
+}

--- a/src/components/EmailFormDialog.js
+++ b/src/components/EmailFormDialog.js
@@ -44,6 +44,7 @@ export default class EmailFormDialog extends React.Component {
               label="Email Address"
               type="email"
               fullWidth
+              required
             />
           </DialogContent>
           <DialogActions>

--- a/src/components/InventoryTable.js
+++ b/src/components/InventoryTable.js
@@ -44,7 +44,7 @@ class InventoryTable extends Component {
     handleRemoveItem(item.name, item.doc_id);
 
     // Notify main app that the database was changed => will refresh inventory state to be re-rendered
-    this.sleepFor(500);    
+    this.sleepFor(750);    
     handleInventoryItemsChanged();
   }
 

--- a/src/components/InventoryTable.js
+++ b/src/components/InventoryTable.js
@@ -9,7 +9,6 @@ import TableRow from '@material-ui/core/TableRow';
 import Paper from '@material-ui/core/Paper';
 import IconButton from '@material-ui/core/IconButton';
 import DeleteIcon from '@material-ui/icons/Delete';
-import SelectInput from '@material-ui/core/Select/SelectInput';
 
 const styles = {
   root: {

--- a/src/components/InventoryTable.js
+++ b/src/components/InventoryTable.js
@@ -9,6 +9,7 @@ import TableRow from '@material-ui/core/TableRow';
 import Paper from '@material-ui/core/Paper';
 import IconButton from '@material-ui/core/IconButton';
 import DeleteIcon from '@material-ui/icons/Delete';
+import SelectInput from '@material-ui/core/Select/SelectInput';
 
 const styles = {
   root: {
@@ -27,18 +28,31 @@ const styles = {
 
 class InventoryTable extends Component {
 
+  // This is a (really bad) function to wait X milliseconds before continuing execution
+  sleepFor(sleepDuration) {
+    var now = new Date().getTime();
+    while (new Date().getTime() < now + sleepDuration) {}
+  }
+
   // This function calls the function provided from App.js, passing in 
   // the item name and document ID (in Firebase) to be deleted.
-  handleClick(item, e) {
+  async handleClick(item, e) {
+    const {handleInventoryItemsChanged} = this.props;
+
+    // Remove the item from the database
     e.preventDefault();
     const { handleRemoveItem } = this.props;
     handleRemoveItem(item.name, item.doc_id);
 
+    // Notify main app that the database was changed => will refresh inventory state to be re-rendered
+    this.sleepFor(500);    
+    handleInventoryItemsChanged();
   }
 
   render() {
     const { classes } = this.props;
     const { inventory } = this.props;
+    console.log(inventory);
 
     return (
       <Paper className={classes.root}>

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -34,13 +34,12 @@ function stringToDate(_date,_format,_delimiter)
 
 // Convert a Date object into a String representation -- not actually used, but I'll keep 
 // the utility function for now.
-function convertDateObjectToString(dateObject) {
+function dateToString(dateObject) {
   var m = new String(dateObject.getMonth() + 1);
-  alert("m length is " + m.length);
   if (m.length === 1) {
       m = "0" + m;
   }
-  var d = new String(dateObject.getDate() + 1);
+  var d = new String(dateObject.getDate());
   if (d.length === 1) {
       d = "0" + d;
   }

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -3,10 +3,7 @@ import { withStyles } from '@material-ui/core/styles';
 import SnackbarContent from '@material-ui/core/SnackbarContent';
 import EmailFormDialog from './EmailFormDialog';
 import PhoneFormDialog from './PhoneFormDialog';
-
-
 import DatePicker from "react-datepicker";
-
 import "react-datepicker/dist/react-datepicker.css";
 
 const styles = theme => ({

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -1,6 +1,9 @@
 import React, { Component } from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import SnackbarContent from '@material-ui/core/SnackbarContent';
+import FormControl from '@material-ui/core/FormControl';
+import Input from '@material-ui/core/Input';
+import InputLabel from '@material-ui/core/InputLabel';
 
 const styles = theme => ({
   snackbar: {
@@ -13,6 +16,7 @@ const styles = theme => ({
   },
 });
 
+// Convert a String to a Date representing that String
 function stringToDate(_date,_format,_delimiter)
 {
   var formatLowerCase=_format.toLowerCase();
@@ -27,7 +31,10 @@ function stringToDate(_date,_format,_delimiter)
   return formatedDate;
 }
 
+// Given a list of items, calculate the items expiring soon
 function calculateItemsExpiringSoon(items, boundaryDate) {
+  items.sort((a,b) => (a.name - b.name));
+
   // Filter out items that expire before May 2nd, 2019
   var itemsFiltered = items.filter(
     item => {
@@ -40,18 +47,48 @@ function calculateItemsExpiringSoon(items, boundaryDate) {
 }
 
 class Landing extends Component { 
+
+  // Set default boundary date and bind the handleChange() function
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      boundaryDate: "05/16/2019"
+    }
+
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  // If the field is changed, update state with the new value
+  handleChange(event) {
+    const name = event.target.name;
+    this.setState({ [name]: event.target.value });
+  }
+
   render () {  
     const { classes } = this.props;      
     const { inventory } = this.props;    
 
-    // Calculate the items expiring soon
-    const boundaryDate = stringToDate("05/10/2019", "mm/dd/yyyy", "/");
-    const itemsExpiringSoon = calculateItemsExpiringSoon(inventory, boundaryDate);
+    // Calculate the items expiring soon, based on the current boundary date
+    var boundaryDateObj = stringToDate(this.state.boundaryDate, "mm/dd/yyyy", "/");
+    const itemsExpiringSoon = calculateItemsExpiringSoon(inventory, boundaryDateObj);
+
     console.log(itemsExpiringSoon);
     return (
       <div className={classes.overall}>
           <h1> Welcome to Chasing Zero </h1>
-          <p> Inventory Items expiring soon: </p>
+          <p>Showing items expiring by the following date (default = 1 week):</p> 
+          <form>
+            <FormControl>
+              <InputLabel>Boundary Date</InputLabel>
+              <Input
+                id="boundaryDate"
+                name="boundaryDate"
+                type="text"
+                value={this.state.boundaryDate}
+                onChange={this.handleChange} />
+            </FormControl>
+          </form>
           <div>
             {
               itemsExpiringSoon.map(inventoryItem =>

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -4,6 +4,8 @@ import SnackbarContent from '@material-ui/core/SnackbarContent';
 import FormControl from '@material-ui/core/FormControl';
 import Input from '@material-ui/core/Input';
 import InputLabel from '@material-ui/core/InputLabel';
+import EmailFormDialog from './EmailFormDialog';
+import PhoneFormDialog from './PhoneFormDialog';
 
 const styles = theme => ({
   snackbar: {
@@ -101,6 +103,16 @@ class Landing extends Component {
               )
             }
           </div>
+          
+          <div style={{marginTop: "50px"}}>
+            <h2>Want to get daily notifications of expiring foods?</h2>
+            <PhoneFormDialog />
+            <p></p>
+            <EmailFormDialog />
+            <p> We will never share your information with any third party. </p>
+          </div>
+          
+
       </div>
     );
    }

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -1,11 +1,13 @@
 import React, { Component } from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import SnackbarContent from '@material-ui/core/SnackbarContent';
-import FormControl from '@material-ui/core/FormControl';
-import Input from '@material-ui/core/Input';
-import InputLabel from '@material-ui/core/InputLabel';
 import EmailFormDialog from './EmailFormDialog';
 import PhoneFormDialog from './PhoneFormDialog';
+
+
+import DatePicker from "react-datepicker";
+
+import "react-datepicker/dist/react-datepicker.css";
 
 const styles = theme => ({
   snackbar: {
@@ -18,7 +20,7 @@ const styles = theme => ({
   },
 });
 
-// Convert a String to a Date representing that String
+// Convert a date from String representation into a Date object
 function stringToDate(_date,_format,_delimiter)
 {
   var formatLowerCase=_format.toLowerCase();
@@ -31,6 +33,23 @@ function stringToDate(_date,_format,_delimiter)
   month-=1;
   var formatedDate = new Date(dateItems[yearIndex],month,dateItems[dayIndex]);
   return formatedDate;
+}
+
+// Convert a Date object into a String representation -- not actually used, but I'll keep 
+// the utility function for now.
+function convertDateObjectToString(dateObject) {
+  var m = new String(dateObject.getMonth() + 1);
+  alert("m length is " + m.length);
+  if (m.length === 1) {
+      m = "0" + m;
+  }
+  var d = new String(dateObject.getDate() + 1);
+  if (d.length === 1) {
+      d = "0" + d;
+  }
+  var y = new String(dateObject.getYear() + 1900);
+
+  return m + "/" + d + "/" + y;
 }
 
 // Given a list of items, calculate the items expiring soon
@@ -54,17 +73,21 @@ class Landing extends Component {
   constructor(props) {
     super(props);
 
+    // Get the date that's exactly one week from the current date
+    var dateObj = new Date();
+    dateObj.setDate(dateObj.getDate() + 7);
     this.state = {
-      boundaryDate: "05/16/2019"
+      boundaryDate: dateObj,
     }
 
     this.handleChange = this.handleChange.bind(this);
   }
 
   // If the field is changed, update state with the new value
-  handleChange(event) {
-    const name = event.target.name;
-    this.setState({ [name]: event.target.value });
+  handleChange(date) {
+    this.setState({
+      boundaryDate: date
+    });
   }
 
   render () {  
@@ -72,7 +95,7 @@ class Landing extends Component {
     const { inventory } = this.props;    
 
     // Calculate the items expiring soon, based on the current boundary date
-    var boundaryDateObj = stringToDate(this.state.boundaryDate, "mm/dd/yyyy", "/");
+    var boundaryDateObj = this.state.boundaryDate;
     const itemsExpiringSoon = calculateItemsExpiringSoon(inventory, boundaryDateObj);
 
     console.log(itemsExpiringSoon);
@@ -80,17 +103,11 @@ class Landing extends Component {
       <div className={classes.overall}>
           <h1> Welcome to Chasing Zero </h1>
           <p>Showing items expiring by the following date (default = 1 week):</p> 
-          <form>
-            <FormControl>
-              <InputLabel>Boundary Date</InputLabel>
-              <Input
-                id="boundaryDate"
-                name="boundaryDate"
-                type="text"
-                value={this.state.boundaryDate}
-                onChange={this.handleChange} />
-            </FormControl>
-          </form>
+          <DatePicker 
+            selected={this.state.boundaryDate}
+            onChange={this.handleChange}
+          />
+
           <div>
             {
               itemsExpiringSoon.map(inventoryItem =>

--- a/src/components/ManageInventory.js
+++ b/src/components/ManageInventory.js
@@ -18,15 +18,18 @@ class ManageInventory extends Component {
     const { classes } = this.props;
     const { inventory } = this.props;
     const { handleRemoveItem } = this.props;
+    const { handleInventoryItemsChanged } = this.props;
 
     return (
       <div>
           <Typography variant="h3" gutterBottom className={classes.title}>Add Items to your Inventory</Typography>
-          <AddInventoryItem />
+          <AddInventoryItem 
+            handleInventoryItemsChanged={handleInventoryItemsChanged} />
           <Typography variant="h3" gutterBottom className={classes.title}> Your Pantry </Typography>
           <InventoryTable 
             inventory={inventory}
-            handleRemoveItem={handleRemoveItem} />
+            handleRemoveItem={handleRemoveItem} 
+            handleInventoryItemsChanged={handleInventoryItemsChanged}/>
       </div>
     )
   }

--- a/src/components/PhoneFormDialog.js
+++ b/src/components/PhoneFormDialog.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import Button from '@material-ui/core/Button';
+import TextField from '@material-ui/core/TextField';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogTitle from '@material-ui/core/DialogTitle';
+
+export default class EmailFormDialog extends React.Component {
+  state = {
+    open: false,
+  };
+
+  handleClickOpen = () => {
+    this.setState({ open: true });
+  };
+
+  handleClose = () => {
+    this.setState({ open: false });
+  };
+
+  render() {
+    return (
+      <div>
+        <Button variant="contained" color="secondary" onClick={this.handleClickOpen}>
+            Sign Up for Text Notifications
+        </Button>
+        <Dialog
+          open={this.state.open}
+          onClose={this.handleClose}
+          aria-labelledby="form-dialog-title"
+        >
+          <DialogTitle id="form-dialog-title">Subscribe</DialogTitle>
+          <DialogContent>
+            <DialogContentText>
+              To receive text notifications of expiring foods, please enter your phone number here. Standard text rates may apply. We will send
+              updates once a day, and you can unsubscribe at any time.
+            </DialogContentText>
+            <TextField
+              autoFocus
+              margin="dense"
+              id="name"
+              label="Phone Number"
+              type="text"
+              fullWidth
+            />
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={this.handleClose} color="primary">
+              Cancel
+            </Button>
+            <Button onClick={this.handleClose} color="primary">
+              Sign Up
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </div>
+    );
+  }
+}

--- a/src/components/PhoneFormDialog.js
+++ b/src/components/PhoneFormDialog.js
@@ -44,6 +44,7 @@ export default class EmailFormDialog extends React.Component {
               label="Phone Number"
               type="text"
               fullWidth
+              required
             />
           </DialogContent>
           <DialogActions>

--- a/src/components/Routes.js
+++ b/src/components/Routes.js
@@ -20,7 +20,8 @@ class Routes extends Component {
         <Route exact path='/ManageInventory' render={
           () => <ManageInventory 
                   inventory={this.props.inventoryState.inventory} 
-                  handleRemoveItem = {this.props.handleRemoveItem} />
+                  handleRemoveItem = {this.props.handleRemoveItem} 
+                  handleInventoryItemsChanged={this.props.handleInventoryItemsChanged}/>
         } />
         <Route exact path='/ShoppingListBuilder' component={ShoppingListBuilder} />
         <Route exact path='/ViewRecipes' render={


### PR DESCRIPTION
Changes to the "Manage Inventory" page:

- The inventory table now automatically refreshes its contents when an item is added or deleted. Previously, this required a page refresh.
- The "bought" and "expires" dates are automatically filled in with default values. By default, the item is considered "bought" on the current date, and it will "expire" exactly 1 week from the current date. A user can still type in a different date to change these values as desired.

Changes to the "Landing" page:
- The user can specify the date of "warning" items that would be expiring soon. The user chooses the date through a DatePicker interface. This automatically updates the warning display with the appropriate food items.
- The user can sign up for daily notifications of expiring foods, by either text or email notification. Choosing either of these will launch a dialog to collect user information, but the app currently doesn't do anything with this contact information.

I tried to document these changes through screenshots with their appropriate commits. 